### PR TITLE
Added support for Unified API

### DIFF
--- a/lib/SimpleStorage.iOS-Unified/SimpleStorage.iOS-Unified.csproj
+++ b/lib/SimpleStorage.iOS-Unified/SimpleStorage.iOS-Unified.csproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SimpleStorage.iOSUnified</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>SimpleStorage.iOS-Unified</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <Compile Include="..\SimpleStorage.iOS\iOSSimpleStorage.cs">
+      <Link>iOSSimpleStorage.cs</Link>
+    </Compile>
+    <Compile Include="..\SimpleStorage.Shared\SimpleStorage.cs">
+      <Link>SimpleStorage.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/lib/SimpleStorage.iOS-Unified/SimpleStorage.iOS-Unified.sln
+++ b/lib/SimpleStorage.iOS-Unified/SimpleStorage.iOS-Unified.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleStorage.iOS-Unified", "SimpleStorage.iOS-Unified.csproj", "{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{28A4A146-C44D-4C00-AA62-C39CB971ED45}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release|iPhone = Release|iPhone
+		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		AppStore|iPhone = AppStore|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.AppStore|iPhone.Build.0 = AppStore|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|iPhone.Build.0 = Debug|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|Any CPU.Build.0 = Release|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|iPhone.ActiveCfg = Release|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|iPhone.Build.0 = Release|iPhone
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{28A4A146-C44D-4C00-AA62-C39CB971ED45}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|iPhone.Build.0 = Release|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Tests\Tests.csproj
+	EndGlobalSection
+EndGlobal

--- a/lib/SimpleStorage.iOS-Unified/Tests/Info.plist
+++ b/lib/SimpleStorage.iOS-Unified/Tests/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>6.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/lib/SimpleStorage.iOS-Unified/Tests/Tests.csproj
+++ b/lib/SimpleStorage.iOS-Unified/Tests/Tests.csproj
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{28A4A146-C44D-4C00-AA62-C39CB971ED45}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Tests</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>Tests</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <BuildIpa>true</BuildIpa>
+    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\AppStore</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="MonoTouch.NUnitLite" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleStorage.iOS-Unified.csproj">
+      <Project>{E7BBD6CA-8399-49CA-B97A-E577A62A97DB}</Project>
+      <Name>SimpleStorage.iOS-Unified</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\SimpleStorage.iOS\Tests\AsyncTests.cs">
+      <Link>AsyncTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\SimpleStorage.iOS\Tests\BasicTests.cs">
+      <Link>BasicTests.cs</Link>
+    </Compile>
+    <Compile Include="..\..\SimpleStorage.iOS\Tests\Main.cs">
+      <Link>Main.cs</Link>
+    </Compile>
+    <Compile Include="..\..\SimpleStorage.iOS\Tests\UnitTestAppDelegate.cs">
+      <Link>UnitTestAppDelegate.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+</Project>

--- a/lib/SimpleStorage.iOS/Tests/Main.cs
+++ b/lib/SimpleStorage.iOS/Tests/Main.cs
@@ -1,8 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#if __UNIFIED__
+using Foundation;
+using UIKit;
+#else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
+#endif
 
 namespace Tests
 {

--- a/lib/SimpleStorage.iOS/Tests/UnitTestAppDelegate.cs
+++ b/lib/SimpleStorage.iOS/Tests/UnitTestAppDelegate.cs
@@ -1,9 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MonoTouch.NUnit.UI;
+
+#if __UNIFIED__
+using Foundation;
+using UIKit;
+#else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
-using MonoTouch.NUnit.UI;
+#endif
 
 namespace Tests
 {

--- a/lib/SimpleStorage.iOS/iOSSimpleStorage.cs
+++ b/lib/SimpleStorage.iOS/iOSSimpleStorage.cs
@@ -1,5 +1,10 @@
 using System;
+
+#if __UNIFIED__
+using Foundation;
+#else
 using MonoTouch.Foundation;
+#endif
 
 namespace PerpetualEngine.Storage
 {

--- a/samples/SimpleStorageDemo.iOS-Unified/Info.plist
+++ b/samples/SimpleStorageDemo.iOS-Unified/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>6.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/samples/SimpleStorageDemo.iOS-Unified/SimpleStorageDemo.iOS-Unified.csproj
+++ b/samples/SimpleStorageDemo.iOS-Unified/SimpleStorageDemo.iOS-Unified.csproj
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{3207D66A-96B4-4537-9276-CC319D968A95}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SimpleStorageDemo.iOSUnified</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>SimpleStorageDemoiOSUnified</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchLink>None</MtouchLink>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <BuildIpa>true</BuildIpa>
+    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\AppStore</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="MonoTouch.Dialog-1" />
+    <Reference Include="SimpleStorage.iOS-Unified">
+      <HintPath>..\..\lib\SimpleStorage.iOS-Unified\SimpleStorage.iOS-Unified.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SimpleStorageDemo.iOS\AppDelegate.cs">
+      <Link>AppDelegate.cs</Link>
+    </Compile>
+    <Compile Include="..\SimpleStorageDemo.iOS\Main.cs">
+      <Link>Main.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/samples/SimpleStorageDemo.iOS-Unified/SimpleStorageDemo.iOS-Unified.sln
+++ b/samples/SimpleStorageDemo.iOS-Unified/SimpleStorageDemo.iOS-Unified.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleStorageDemo.iOS-Unified", "SimpleStorageDemo.iOS-Unified.csproj", "{3207D66A-96B4-4537-9276-CC319D968A95}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release|iPhone = Release|iPhone
+		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		AppStore|iPhone = AppStore|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.AppStore|iPhone.Build.0 = AppStore|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Debug|iPhone.Build.0 = Debug|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Release|iPhone.ActiveCfg = Release|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Release|iPhone.Build.0 = Release|iPhone
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{3207D66A-96B4-4537-9276-CC319D968A95}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = SimpleStorageDemo.iOS-Unified.csproj
+	EndGlobalSection
+EndGlobal

--- a/samples/SimpleStorageDemo.iOS/AppDelegate.cs
+++ b/samples/SimpleStorageDemo.iOS/AppDelegate.cs
@@ -1,10 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
 using MonoTouch.Dialog;
 using PerpetualEngine.Storage;
+
+#if __UNIFIED__
+using Foundation;
+using UIKit;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
 
 namespace SimpleStorageDemo.iOS
 {

--- a/samples/SimpleStorageDemo.iOS/Main.cs
+++ b/samples/SimpleStorageDemo.iOS/Main.cs
@@ -1,8 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#if __UNIFIED__
+using Foundation;
+using UIKit;
+#else
 using MonoTouch.Foundation;
 using MonoTouch.UIKit;
+#endif
 
 namespace SimpleStorageDemo.iOS
 {


### PR DESCRIPTION
In keeping with the current setup, I've created a separate solution for the unified API support.

Although I've opted to link to the source from the classic API source, I think this is probably a poor approach. I think it would make more sense to have two projects under 'SimpleStorage.iOS', one for each of the APIs.

As this is your component, I thought I'd defer to your judgement and am happy to revise this PR to suit.
